### PR TITLE
win32 build fixes: use pkg-config to find expat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ build = "build.rs"
 [lib]
 name = "expat_sys"
 path = "lib.rs"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+extern crate pkg_config;
+
 use std::process::Command;
 use std::env;
 
 
 fn main() {
+    if pkg_config::Config::new().atleast_version("2.1.0").find("expat").is_ok()
+    {
+        return;
+    }
+
     assert!(Command::new("make")
         .args(&["-f", "makefile.cargo"])
         .status()


### PR DESCRIPTION
Use pkg-config to find a system expat, and use it if possible.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/libexpat/10)
<!-- Reviewable:end -->
