### PR TITLE
Allows compilation regardless whether system make is gnumake or not.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ path = "lib.rs"
 
 [build-dependencies]
 pkg-config = "0.3"
+make-cmd = "*"

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate pkg_config;
+extern crate make_cmd;
 
-use std::process::Command;
 use std::env;
-
 
 fn main() {
     if pkg_config::Config::new().atleast_version("2.1.0").find("expat").is_ok()
@@ -14,7 +13,7 @@ fn main() {
         return;
     }
 
-    assert!(Command::new("make")
+    assert!(make_cmd::make()
         .args(&["-f", "makefile.cargo"])
         .status()
         .unwrap()


### PR DESCRIPTION
On BSDs, gnumake is the binary "gmake".

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/libexpat/12)
<!-- Reviewable:end -->
