### PR TITLE
Bump version number to 2.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expat-sys"
-version = "2.1.1-really.0"
+version = "2.1.1"
 authors = ["Expat maintainers"]
 links = "expat"
 build = "build.rs"


### PR DESCRIPTION
Version number 2.1.1-really.0 is a prerelease.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/libexpat/13)
<!-- Reviewable:end -->
