### PR TITLE
Do not use pkg-config on Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expat-sys"
-version = "2.1.5"
+version = "2.1.6"
 authors = ["Expat maintainers"]
 links = "expat"
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -8,8 +8,14 @@ extern crate pkg_config;
 use std::env;
 
 fn main() {
-    if pkg_config::Config::new().atleast_version("2.1.0").find("expat").is_ok() {
-        return
+    let target = env::var("TARGET").unwrap();
+    if !target.contains("android")
+        && pkg_config::Config::new()
+            .atleast_version("2.1.0")
+            .find("expat")
+            .is_ok()
+    {
+        return;
     }
 
     let mut dst = cmake::Config::new("expat")


### PR DESCRIPTION
This is required for https://github.com/servo/servo/issues/21619.

It is currently working on Servo's Android build because we are not setting the `PKG_CONFIG_ALLOW_CROSS` env var and pkg-config is not used, but we need to set it to build `servo-media` dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/libexpat/22)
<!-- Reviewable:end -->
