### PR TITLE
Fix musl compilation on Fedora

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,7 @@ fn main() {
     };
 
     let mut dst = cfg
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .define("BUILD_shared", "OFF")
         .define("BUILD_tools", "OFF")
         .define("BUILD_examples", "OFF")

--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -1,7 +1,7 @@
 # This file is copyrighted under the BSD-license for buildsystem files of KDE
 # copyright 2010, Patrick Spendrin <ps_ml@gmx.de>
 
-project(expat)
+project(expat C)
 
 cmake_minimum_required(VERSION 2.8.10)
 set(PACKAGE_BUGREPORT "expat-bugs@libexpat.org")


### PR DESCRIPTION
Hardcode the name of the library folder for cmake to match the other hardcoded reference. `expat` is also declared as a C project to avoid a dependency on a C++ compiler.